### PR TITLE
Clean up the README a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-#Drafting Dynamically
-This is a set of tools for quickly being able to follow drafting patterns, specifically the "single-breasted waistcoat" from 'The "Keystone" jacket and dress cutter'. 
+# Drafting Dynamically
+
+This is a set of tools for quickly being able to follow drafting patterns, specifically the "single-breasted waistcoat" from 'The "Keystone" jacket and dress cutter'. (See it online [here](https://kylabendrik.github.io/drafting-dynamically/))
 
 This book from 1895 is full of excellent information about some basic tailored garments of the period. While the book is freely available online, it is also kind of difficult to follow at times. 
 The old-fashioned language, out-of-order steps, and odd labeling choices make the process somewhat hard to follow. 


### PR DESCRIPTION
Fix the title, and add a link to the live site.

Currently the title does not act like a title at all, and is combined with the paragraph below it. This is because the file was missing a space after the header type (`#`) and an empty line after the end of the header.

![image](https://github.com/user-attachments/assets/00c79ebc-64a6-4a32-8d2b-86b4db080048)
